### PR TITLE
Fix map link and HTML markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,5 @@
 </head>
 <body>
     <div id="container" class="grid-container"></div>
-</div>
 </body>
 </html>

--- a/parkings.js
+++ b/parkings.js
@@ -2,7 +2,8 @@ var url = "https://data.rennesmetropole.fr/api/records/1.0/search/?dataset=tco-p
 
 function openMap(name, x, y) {
   let coord = x+","+y;
-  window.open("maps://?q="+encodeURIComponent(name)+"&near="+coord+"&ll="+coord+"&sll="+coord);
+  const query = encodeURIComponent(`${name} (${coord})`);
+  window.open(`https://www.google.com/maps/search/?api=1&query=${query}`);
 }
 
 var getJSON = function(url, callback) {


### PR DESCRIPTION
## Summary
- open map links via standard Google Maps URL instead of non-standard scheme
- remove stray closing div from index.html

## Testing
- `node --check parkings.js`
- `npx htmlhint index.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6895c6d7d0c08322886dbbe7cf178006