### PR TITLE
Add responsive design for parking status viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,41 +2,11 @@
 <html lang="fr">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script src="parkings.js"></script>
-    <style>
-        .grid-container {
-            display: grid;
-            /* grid-template-columns: repeat(auto-fit, minmax(500px, 1fr)); */
-            grid-gap: 20px;
-        }
-
-        .grid-item {
-            text-align: center;
-            border: solid 1px black;
-        }
-
-        @media (min-width: 480px) {
-            .grid-container {
-                grid-template-columns: repeat(1, 1fr);
-            }
-        }
-
-        @media (min-width: 768px) {
-            .grid-container {
-                grid-template-columns: repeat(2, 1fr);
-            }
-        }
-
-        @media (min-width: 1024px) {
-            .grid-container {
-                grid-template-columns: repeat(3, 1fr);
-            }
-        }
-
-    </style>
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <div id="container" class="grid-container"></div>
-</div>
 </body>
 </html>

--- a/parkings.js
+++ b/parkings.js
@@ -34,10 +34,10 @@ function info_update(fields) {
   places.innerHTML = "";
 
   if (fields.etatremplissage === "LIBRE"){
-    status.style = "color: GREEN;";
+    status.className = "status-free";
     places.innerHTML = fields.jrdinfosoliste;
   }else{
-    status.style = "color: RED;";
+    status.className = "status-full";
     places.innerHTML = "";
   }
 

--- a/style.css
+++ b/style.css
@@ -1,0 +1,53 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 2rem;
+  background-color: #f4f4f4;
+}
+
+.grid-container {
+  display: grid;
+  grid-gap: 20px;
+}
+
+.grid-item {
+  text-align: center;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  background-color: #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  padding: 1rem;
+  cursor: pointer;
+}
+
+.grid-item h1,
+.grid-item h2,
+.grid-item h3 {
+  margin: 0.5rem 0;
+}
+
+.status-free {
+  color: #2e7d32;
+}
+
+.status-full {
+  color: #c62828;
+}
+
+@media (min-width: 480px) {
+  .grid-container {
+    grid-template-columns: repeat(1, 1fr);
+  }
+}
+
+@media (min-width: 768px) {
+  .grid-container {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  .grid-container {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}


### PR DESCRIPTION
## Summary
- Move inline styles into a dedicated `style.css`
- Improve layout with responsive grid and body styling
- Use CSS classes for parking status indicators

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895c7bf46a88322bdc9b7b8798d0b14